### PR TITLE
Update Remote Falcon Org

### DIFF
--- a/pluginList.json
+++ b/pluginList.json
@@ -37,7 +37,7 @@
 		[ "FPP-Plugin-Twitter", "https://raw.githubusercontent.com/FalconChristmas/fpp-pluginList/master/oldplugins/pluginInfo-FPP-Plugin-Twitter.json" ],
 		[ "fpp-tirprog", "https://raw.githubusercontent.com/FalconChristmas/fpp-pluginList/master/oldplugins/pluginInfo-fpp-tirprog.json" ],
 		[ "model-testing", "https://raw.githubusercontent.com/FalconChristmas/fpp-pluginList/master/oldplugins/pluginInfo-model-testing.json" ],
-		[ "remote-falcon", "https://raw.githubusercontent.com/whitesoup12/remote-falcon-plugin/master/pluginInfo.json" ],
+		[ "remote-falcon", "https://raw.githubusercontent.com/remote-falcon/remote-falcon-plugin/master/pluginInfo.json" ],
 		[ "show-on-demand", "https://raw.githubusercontent.com/joeharrison714/show-on-demand-plugin/master/pluginInfo.json" ],
         [ "fpp-smartthings-plugin", "https://raw.githubusercontent.com/joeharrison714/fpp-smartthings-plugin/master/pluginInfo.json" ],
 		[ "fpp-sms-control-too", "https://raw.githubusercontent.com/joeharrison714/fpp-sms-control-too/master/pluginInfo.json" ],


### PR DESCRIPTION
Updated the Remote Falcon plugin to point to the new Remote Falcon Github Org.