### PR TITLE
Add FPP-Simple-Weather plugin to pluginList.json

### DIFF
--- a/pluginList.json
+++ b/pluginList.json
@@ -55,6 +55,7 @@
 		[ "fpp-WLED-Control", "https://raw.githubusercontent.com/CaffeinatedFunctionality/fpp-WLED-Control/master/pluginInfo.json"],
 		[ "fpp-PulseMesh", "https://raw.githubusercontent.com/PulseMeshLabs/fpp-pulsemesh/refs/heads/main/pluginInfo.json"],
 		[ "fpp-sumup", "https://raw.githubusercontent.com/PiSignage/fpp-sumup/refs/heads/master/pluginInfo.json" ],
-		[ "fpp-plugin-BackgroundMusic", "https://raw.githubusercontent.com/OnlineDynamic/BackgroundMusicFPP-Plugin/refs/heads/master/pluginInfo.json" ]
+		[ "fpp-plugin-BackgroundMusic", "https://raw.githubusercontent.com/OnlineDynamic/BackgroundMusicFPP-Plugin/refs/heads/master/pluginInfo.json" ],
+		[ "FPP-Simple-Weather", "https://raw.githubusercontent.com/toddejohnson/FPP-Simple-Weather/refs/heads/main/pluginInfo.json" ],
 	]
 }


### PR DESCRIPTION
I loved @Poporacer 's FPP-Simple-Countdown's simplicity and Overlay Text Effect. I forked that and pulled in some weather from OpenWeatherMap and I use my weather station in the back yard so I added the option to use AmbientWeather's API.  

https://github.com/toddejohnson/FPP-Simple-Weather

I do have some work to:
* [x] OpenWeatherMap API by lat/lon and City, State, Country
* [x] AmbientWeatherAPI by AppID, APIKey, Device index
* [x] include other units(I hardcoded to F and MPH which isn't Christmas like)
* [ ] AJAH for weather info in plugin. I'm still looking for an example

I'm happy to move this into FalconChristmas org if wanted(or feel free to steal it back @Poporacer). 