### PR TITLE
Update pluginList.json

### DIFF
--- a/pluginList.json
+++ b/pluginList.json
@@ -1,5 +1,6 @@
 {
 	"pluginList": [
+		[ "fpp-AnnouncementAssistant", "https://raw.githubusercontent.com/focusedonsound/fpp-AnnouncementAssistant/refs/heads/main/pluginInfo.json" ],
 		[ "fpp-BigButtons", "https://raw.githubusercontent.com/FalconChristmas/fpp-BigButtons/master/pluginInfo.json" ],
 		[ "fpp-vastfmt", "https://raw.githubusercontent.com/FalconChristmas/fpp-vastfmt/master/pluginInfo.json" ],
 		[ "Si4713_FM_RDS", "https://raw.githubusercontent.com/ShadowLight8/Si4713_FM_RDS/master/pluginInfo.json" ],


### PR DESCRIPTION
Add fpp-AnnouncementAssistant

Announcement Assistant adds instant, one-tap announcement buttons to FPP — and it plays your pre-recorded messages over the currently playing show audio with automatic ducking (the show keeps running, the message is crystal clear). No awkward pauses. No “dead air.” Just clean overlays that sound like you planned it that way.