### PR TITLE
Add fpp-SETIQ (SET:IQ + REQ:IQ) plugin

### DIFF
--- a/pluginList.json
+++ b/pluginList.json
@@ -64,6 +64,7 @@
 		[ "Statistics-Fpp-Plugin", "https://raw.githubusercontent.com/OnlineDynamic/Statistics-Fpp-Plugin/refs/heads/master/pluginInfo.json" ],
 		[ "fpp-servo-calibrator", "https://raw.githubusercontent.com/pgianotto/fpp-servo-calibrator/master/pluginInfo.json" ],
 		[ "fpp-live-follow", "https://raw.githubusercontent.com/pgianotto/fpp-live-follow/master/pluginInfo.json" ],
-		[ "fpp-performance-capture", "https://raw.githubusercontent.com/pgianotto/animatronic-motion-system/master/pluginInfo.json" ]
+		[ "fpp-performance-capture", "https://raw.githubusercontent.com/pgianotto/animatronic-motion-system/master/pluginInfo.json" ],
+		[ "fpp-SETIQ", "https://raw.githubusercontent.com/diaquas/fpp-SETIQ/main/pluginInfo.json" ]
 	]
 }


### PR DESCRIPTION
Adds the fpp-SETIQ plugin from Lights of Elm Ridge. SET:IQ pulls cloud-generated playlists onto the FPP box with one click; REQ:IQ is a background listener that lets viewers see what's playing and request songs from their phones, with requests inserted into playback automatically. Runs entirely on the FPP host. Repo: https://github.com/diaquas/fpp-SETIQ — pluginInfo.json validated against fpp-plugin-Template, minFPPVersion 8.0+